### PR TITLE
FIX make sur coordinate file contain 'pmid'

### DIFF
--- a/neuroquery/datasets.py
+++ b/neuroquery/datasets.py
@@ -88,6 +88,7 @@ def fetch_peak_coordinates(data_dir=None):
     # gzip format."
     content_buf = io.BytesIO(content)
     df = pd.read_csv(content_buf, sep="\t")
+    df = df.rename(columns={'id': 'pmid'})
     df.to_csv(str(out_file), index=False)
     print("Downloaded.")
     return out_file

--- a/neuroquery/tests/test_datasets.py
+++ b/neuroquery/tests/test_datasets.py
@@ -11,7 +11,9 @@ from neuroquery import datasets
 
 class _FileResponse(object):
     def __init__(self, data_file):
-        self.data_file = str(pathlib.Path(__file__).parent / "data" / data_file)
+        self.data_file = str(
+            pathlib.Path(__file__).parent / "data" / data_file
+        )
         self.status_code = 200
         with open(self.data_file, "rb") as f:
             self.content = f.read()
@@ -60,6 +62,7 @@ def test_fetch_peak_coordinates():
             coord_file = datasets.fetch_peak_coordinates(tmp_dir)
             df = pd.read_csv(coord_file)
             assert df.shape == (20, 6)
+            assert 'pmid' in df.columns
             coord_file = datasets.fetch_peak_coordinates(tmp_dir)
             mock_get.assert_called_once()
 


### PR DESCRIPTION
Fixes #11 by mapping `id` to `pmid` when saving the `coordinate.csv` file.

Also add a check in test that the generated file contains `pmid`.