### PR TITLE
Fix for scipy deprecation

### DIFF
--- a/examples/examples_src/training_neuroquery.py
+++ b/examples/examples_src/training_neuroquery.py
@@ -77,7 +77,7 @@ pmids = brain_maps.index.intersection(corpus_metadata["pmid"])
 rindex = pd.Series(
     np.arange(corpus_metadata.shape[0]), index=corpus_metadata["pmid"]
 )
-tfidf = tfidf.A[rindex.loc[pmids].values, :]
+tfidf = tfidf.toarray()[rindex.loc[pmids].values, :]
 brain_maps = brain_maps.loc[pmids, :]
 
 ######################################################################

--- a/src/neuroquery/encoding.py
+++ b/src/neuroquery/encoding.py
@@ -142,7 +142,7 @@ class NeuroQueryModel:
         if vocabulary is None:
             vocabulary = self.full_vocabulary()
         if sparse.issparse(tfidf):
-            tfidf = tfidf.A.squeeze()
+            tfidf = tfidf.toarray().squeeze()
         similar = pd.Series(tfidf, index=vocabulary).sort_values(
             ascending=False
         )

--- a/src/neuroquery/nmf.py
+++ b/src/neuroquery/nmf.py
@@ -66,7 +66,7 @@ class CovarianceSmoothing(BaseEstimator, TransformerMixin):
 
     def transform(self, X):
         if sparse.issparse(X):
-            X = X.A
+            X = X.toarray()
         s = np.einsum(
             "ij,jk,lk", X, self.normalized_V_, self.V_, optimize=True
         )

--- a/src/neuroquery/ridge.py
+++ b/src/neuroquery/ridge.py
@@ -41,6 +41,7 @@ def _gcv(U, s, Y, intercept, alphas):
 
 
 def ridge_gcv(X, Y, alphas=_DEFAULT_ALPHAS, feat_penalty=None):
+    alphas = alphas.astype(X.dtype)
     X, X_mean, Y, intercept = _preprocess(X, Y, feat_penalty)
     U, s, Vh = linalg.svd(X, full_matrices=False)
     V = Vh.T

--- a/src/neuroquery/smoothed_regression.py
+++ b/src/neuroquery/smoothed_regression.py
@@ -49,7 +49,7 @@ class SmoothedRegression(BaseEstimator, RegressorMixin):
 
     def fit(self, X, Y):
         if sparse.issparse(X):
-            X = X.A
+            X = X.toarray()
         self.smoothing_ = nmf.CovarianceSmoothing(
             n_components=self.n_components,
             smoothing_weight=self.smoothing_weight,

--- a/tests/test_nmf.py
+++ b/tests/test_nmf.py
@@ -26,7 +26,7 @@ def test_covariance_smoothing():
     a = sparse.csr_matrix(((1.0,), (0,), (0, 1)), shape=(1, 7))
     s = op.transform(a)
     assert np.allclose(
-        s, a.A.ravel() * 0.9 + 0.1 * op.normalized_V_.dot(op.V_.T)[0]
+        s, a.toarray().ravel() * 0.9 + 0.1 * op.normalized_V_.dot(op.V_.T)[0]
     )
     smoothed = nmf.CovarianceSmoothing(
         n_components=5, smoothing_weight=0.0

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -331,7 +331,7 @@ def test_highlight_text():
 
 def test_unigrams():
     voc = ["working memory", "brain", "memory"]
-    op = tokenization.unigram_operator(voc).A
+    op = tokenization.unigram_operator(voc).toarray()
     assert np.allclose(op, [[1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     freq = tokenization.add_unigram_frequencies([1, 1, 1], voc=voc)
     assert np.allclose(freq, [1, 1, 2])
@@ -341,17 +341,17 @@ def test_text_vectorizer():
     docs = ["attention Encoding-language", "routine fixation", "ab and action"]
     vect = tokenization.TextVectorizer.from_vocabulary_file(VOCABULARY_FILE)
     transformed = vect(docs)
-    assert np.allclose(transformed.A[2, :4], [0.83618742, 0.5484438, 0.0, 0.0])
+    assert np.allclose(transformed.toarray()[2, :4], [0.83618742, 0.5484438, 0.0, 0.0])
     vect = tokenization.TextVectorizer.from_vocabulary_file(
         VOCABULARY_FILE, use_idf=False, norm="l1", add_unigrams=False
     )
     transformed = vect(docs)
-    assert np.allclose(transformed.A[2, :4], [0.5, 0.5, 0.0, 0.0])
+    assert np.allclose(transformed.toarray()[2, :4], [0.5, 0.5, 0.0, 0.0])
     vect = tokenization.TextVectorizer.from_vocabulary(
         vect.get_vocabulary(), norm="l1"
     )
     transformed = vect(docs)
-    assert np.allclose(transformed.A[2, :4], [0.5, 0.5, 0.0, 0.0])
+    assert np.allclose(transformed.toarray()[2, :4], [0.5, 0.5, 0.0, 0.0])
     assert vect.get_feature_names() == vect.tokenizer.get_vocabulary()
     assert vect.get_full_vocabulary() == vect.tokenizer.get_full_vocabulary()
 
@@ -363,6 +363,6 @@ def test_text_vectorizer_non_whitespace_pattern():
         voc, token_pattern=pattern, use_idf=False, norm=None
     )
     text = ["something z > 10 z  >= z >  and one two"]
-    transformed = vectorizer.transform(text).A.ravel()
+    transformed = vectorizer.transform(text).toarray().ravel()
     assert vectorizer.get_vocabulary() == ["one two", "z >"]
     assert np.allclose(transformed, [1, 2])


### PR DESCRIPTION
Replaces `csr_matrix.A` with `csr_matrix.toarray()`. From scipy 1.14.0 release [notes](https://github.com/scipy/scipy/releases/tag/v1.14.0):
> the .A and .H attributes were removed.

Also fixes a dtype test that was failing for me. 
